### PR TITLE
fix Claude temperature/top_p conflict for OpenAI-compatible endpoints

### DIFF
--- a/LlmExtension/Pages/LlmExtensionPage.cs
+++ b/LlmExtension/Pages/LlmExtensionPage.cs
@@ -124,13 +124,13 @@ internal sealed partial class LlmExtensionPage : DynamicListPage
                 {
                     MaxTokens = Config.MaxTokens,
                     Temperature = Config.Temperature,
-                    TopP = Config.TopP,
+                    TopP = Config.TopP == 1.0f ? null : Config.TopP,
                 },
                 LlmExtensionPage.Service.AzureOpenAI => new AzureOpenAIPromptExecutionSettings()
                 {
                     MaxTokens = Config.MaxTokens,
                     Temperature = Config.Temperature,
-                    TopP = Config.TopP,
+                    TopP = Config.TopP == 1.0f ? null : Config.TopP,
                 },
                 LlmExtensionPage.Service.Google => new GeminiPromptExecutionSettings()
                 {


### PR DESCRIPTION
Fixes #14

When using Claude models via an OpenAI-compatible endpoint (e.g. Vertex AI, LiteLLM proxy), 
the extension fails because both `temperature` and `top_p` are always sent together, 
and Claude rejects requests where both are specified simultaneously.

**Fix:** Only send `top_p` when it has been explicitly changed from its default value (`1.0`). 
When `top_p` is at the default, it is omitted from the request so only `temperature` is sent.

This applies to both the `OpenAI` and `AzureOpenAI` service paths.
